### PR TITLE
Fixed a few compiler issues in stb_vorbis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 vorbis
 ======
 
-This is a fork of [Steve McCoy's binding](http://github.com/mccoyst/vorbis/) of stb_vorbis.
-
 This Go package provides a "native" ogg vorbis decoder, but still requires cgo, as it uses inline code from [stb_vorbis](http://nothings.org/stb_vorbis/). Someday, it won't.
 
 The package exports a single function:


### PR DESCRIPTION
I've tried to get rid of anything that causes compiler warnings for the sake of a clean build, and I don't believe it's had any effect on functionality. Since GCC on Linux requires the -lm flag to include "math.h", I've added that as a #cgo preprocessor to add that when necessary. This has been tested on Windows 8 (64-bit) and Linux Mint 12 (32-bit).
